### PR TITLE
Financial details movedout bugfix

### DIFF
--- a/ahapp.cpp
+++ b/ahapp.cpp
@@ -4327,7 +4327,7 @@ void CAhApp::ShowLandFinancial(CLand * pCurLand)
                 {
                     SilvRes += (long)value;
 
-                    if (pUnit->pMovement && pUnit->pMovement->Count()>0)
+                    if (pUnit->pMovement && pUnit->pMovement->Count()>0 && ((long)value > 0))
                         MovedOut += (long)value;
                 }
             }

--- a/atlaparser.cpp
+++ b/atlaparser.cpp
@@ -7074,7 +7074,7 @@ void CAtlaParser::RunOrder_Move(CStr & Line, CStr & ErrorLine, BOOL skiperror, C
     CLand             * pLandCurrent = pLand;
     long                hexId = 0;
     long                newHexId = 0;
-    int                 currentStruct = 0;
+    long                currentStruct = 0;
     int                 totalMovementCost = 0;
     bool                pathCanBeTraced = true;
     int                 movementMode = 0;
@@ -7105,7 +7105,7 @@ void CAtlaParser::RunOrder_Move(CStr & Line, CStr & ErrorLine, BOOL skiperror, C
         // Determine whether the unit is currently in a structure
         if (pUnit->GetProperty(PRP_STRUCT_ID, type, value, eNormal) && eLong==type)
         {
-            currentStruct = (int)value;
+            currentStruct = (long)value;
         }
 
         while (params)

--- a/atlaparser.cpp
+++ b/atlaparser.cpp
@@ -1249,11 +1249,23 @@ plain (5,39) in Partry, contains Drimnin [city], 3217 peasants (high
     src      = Section.GetToken(srcold, '.', TRIM_ALL);
     if (!m_IsHistory && m_CurYearMon>0)
         ParseWeather(src, pLand);  // weather description should be right after the first section
+        
     while (!Section.IsEmpty())
     {
         BOOL RerunSection = FALSE;
 
         str = Section.GetData();
+        
+        // When weather is not activated the dashed (----) is not cleaned. Do it here
+	    str = SkipSpaces(str);
+	    if ('-'==str[0] && '-'==str[1] && '-'==str[2] )
+	    {
+	        while (*str > ' ')
+	            str++;
+	        str = SkipSpaces(str);
+	    }
+	    
+	    // Parse land data
         while (str)
         {
             if (RerunSection)


### PR DESCRIPTION
When units leave an hex with a negative amount of silver (because of buying) the total amount is added to the financial details, because we're substracting a negative value.

But actually the unit should not add money to the region. This amount will be deducted from other sharing units or the buy command will fail (and thus it is correct showing a negative balance). So when a unit with negative amount of silver leaves a region no substraction is done.